### PR TITLE
chore: update repo name in Antora playbook

### DIFF
--- a/playbook/antora-playbook.yml
+++ b/playbook/antora-playbook.yml
@@ -5,11 +5,11 @@ site:
 
 content:
   sources:
-    - url: https://github.com/jenkins-infra/jenkins-io-docs.git
+    - url: https://github.com/jenkins-infra/docs.jenkins.io.git
       branches: [main]
       start_paths: [docs/tutorials, docs/user-docs, docs/solutions]
       # developer docs are un-versioned that's why they are to be fetched individually
-    - url: https://github.com/jenkins-infra/jenkins-io-docs.git
+    - url: https://github.com/jenkins-infra/docs.jenkins.io.git
       branches: [main]
       start_paths: [docs/dev-docs, docs/events, docs/security, docs/sigs, docs/projects, docs/images, docs/books, docs/community, docs/project, docs/about, docs/download]
 
@@ -30,5 +30,5 @@ asciidoc:
     
 ui:
   bundle:
-    url: https://github.com/jenkins-infra/jenkins-io-docs/blob/main/ui/build/ui-bundle.zip
+    url: https://github.com/jenkins-infra/docs.jenkins.io/blob/main/ui/build/ui-bundle.zip
     snapshot: true


### PR DESCRIPTION
This PR updates Antora playbook to take in account the new repository name.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3885#issuecomment-1893462138