### PR TITLE
chore: lint Antora playbooks

### DIFF
--- a/playbook/antora-playbook.yml
+++ b/playbook/antora-playbook.yml
@@ -1,3 +1,4 @@
+---
 site:
   title: Jenkins Docs
   url: https://docs.jenkins.com
@@ -7,11 +8,27 @@ content:
   sources:
     - url: https://github.com/jenkins-infra/jenkins-io-docs.git
       branches: [main]
-      start_paths: [docs/tutorials, docs/user-docs, docs/solutions]
-      # developer docs are un-versioned that's why they are to be fetched individually
+      start_paths: [
+        docs/solutions,
+        docs/tutorials,
+        docs/user-docs
+      ]
+      # developer docs are un-versioned that's why they're fetched individually
     - url: https://github.com/jenkins-infra/jenkins-io-docs.git
       branches: [main]
-      start_paths: [docs/dev-docs, docs/events, docs/security, docs/sigs, docs/projects, docs/images, docs/books, docs/community, docs/project, docs/about, docs/download]
+      start_paths: [
+        docs/about,
+        docs/books,
+        docs/community,
+        docs/dev-docs,
+        docs/download,
+        docs/events,
+        docs/images,
+        docs/project,
+        docs/projects,
+        docs/security,
+        docs/sigs
+      ]
 
 runtime:
   cache_dir: ./.cache/antora
@@ -27,7 +44,7 @@ asciidoc:
     jep: https://github.com/jenkinsci/jep/tree/master/jep/
     matrix: https://matrix.to/#/#
     email: jenkinsci-users@googlegroups.com
-    
+
 ui:
   bundle:
     url: https://github.com/jenkins-infra/jenkins-io-docs/blob/main/ui/build/ui-bundle.zip

--- a/playbook/local-antora-playbook.yml
+++ b/playbook/local-antora-playbook.yml
@@ -1,3 +1,4 @@
+---
 site:
   title: Jenkins Docs
   start_page: user-docs::index.adoc
@@ -5,14 +6,30 @@ site:
 content:
   sources:
     - url: ../
-      # remember well to change the branch name to the one you are working on to generate the preview
+      # Change the branch name to the one you are working on for preview
       branches: [main]
-      start_paths: [docs/tutorials, docs/user-docs, docs/solutions]
-      # developer docs are un-versioned that's why they are to be fetched individually
+      start_paths: [
+        docs/solutions,
+        docs/tutorials,
+        docs/user-docs
+      ]
+      # developer docs are un-versioned that's why they're fetched individually
     - url: ../
-      # remember well to change the branch name to the one you are working on to generate the preview
+      # Change the branch name to the one you are working on for preview
       branches: [main]
-      start_paths: [docs/dev-docs, docs/events, docs/security, docs/sigs, docs/projects, docs/images, docs/books, docs/community, docs/project, docs/about, docs/download]
+      start_paths: [
+        docs/about,
+        docs/books,
+        docs/community,
+        docs/dev-docs,
+        docs/download,
+        docs/events,
+        docs/images,
+        docs/project,
+        docs/projects,
+        docs/security,
+        docs/sigs
+      ]
 
 runtime:
   cache_dir: ./.cache/antora
@@ -28,7 +45,7 @@ asciidoc:
     jep: https://github.com/jenkinsci/jep/tree/master/jep/
     matrix: https://matrix.to/#/#
     email: jenkinsci-users@googlegroups.com
-    
+
 ui:
   bundle:
     url: ../ui/build/ui-bundle.zip


### PR DESCRIPTION
This PR:
- Adds YAML document start `---`
- Sort and format `start_paths` arrays to avoid "too long line" warning
- Reword comments to avoid "too long line" warning
- Remove trailing spaces