### PR TITLE
Fix references to JEP

### DIFF
--- a/docs/dev-docs/modules/internationalization/pages/index.adoc
+++ b/docs/dev-docs/modules/internationalization/pages/index.adoc
@@ -38,7 +38,7 @@ Translators need to perform the following tasks for Jenkins core and plugins tha
 == Chinese localization
 
 If you want to contribute Chinese localization, please create a PR in the link:https://github.com/jenkinsci/localization-zh-cn-plugin[Simplified Chinese Plugin].
-More details on the Chinese localization plugin are available from {jep}216/README.adoc[].
+More details on the Chinese localization plugin are available from {jep}216/README.adoc[JEP-216].
 
 == IntelliJ IDEA plugin
 

--- a/docs/dev-docs/modules/plugin-development/pages/dependencies-and-class-loading.adoc
+++ b/docs/dev-docs/modules/plugin-development/pages/dependencies-and-class-loading.adoc
@@ -476,4 +476,4 @@ For purposes of class loading, these components behave like anything else bundle
 For Maven dependency management purposes, plugins can declare `provided`-scope dependencies on these modules if they wish to use their APIs,
 taking care to select the same version as is bundled in the baseline version of core.
 
-{jep}230/README.adoc[] removed this system at least from the default Jenkins distribution.
+{jep}230/README.adoc[JEP-230] removed this system at least from the default Jenkins distribution.

--- a/docs/dev-docs/modules/publishing/pages/releasing-cd.adoc
+++ b/docs/dev-docs/modules/publishing/pages/releasing-cd.adoc
@@ -1,6 +1,6 @@
 = Setting up automated plugin release
 
-NOTE: Continuous Delivery of Jenkins Components and Plugin (jep:229[]) is relatively new.
+NOTE: Continuous Delivery of Jenkins Components and Plugin ({jep}229[JEP-229]) is relatively new.
 Any feedback from early adopters will be appreciated.
 
 == Introduction

--- a/docs/project/modules/ROOT/pages/governance.adoc
+++ b/docs/project/modules/ROOT/pages/governance.adoc
@@ -150,7 +150,7 @@ Chats::
 Jenkins project uses xref:community:chat:index.adoc[IRC and Gitter channels] for real time interactive communications. This is also the place where active members bond with each other.
 
 Twitter::
-link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account of the Jenkins project, run by the team of contributors (jep:10[]).
+link:https://twitter.com/jenkinsci[@jenkinsci] is the official Twitter account of the Jenkins project, run by the team of contributors ({jep}10[JEP-10]).
 There are also a link:https://twitter.com/jenkins_release[@jenkins_release] account for automatic plugin release announcements,
 and other accounts being run by sub-communities like meetup groups.
 
@@ -192,7 +192,7 @@ All initiatives depend on contributions,
 and we invite all interested parties to join us and to contribute towards the roadmap goals.
 
 * link:https://www.jenkins.io/project/roadmap[Public Jenkins Roadmap]
-* jep:14[Public Jenkins Roadmap Process]
+* {jep}14[Public Jenkins Roadmap Process]
 
 [#meeting]
 == Decision making

--- a/docs/projects/modules/gsoc/pages/2020/projects/external-fingerprint-storage.adoc
+++ b/docs/projects/modules/gsoc/pages/2020/projects/external-fingerprint-storage.adoc
@@ -67,7 +67,7 @@ repository] was also created for the purpose of this project and
 link:https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/blob/master/README.adoc[README] contains
 installation and usage instructions.
 
-* The external fingerprint storage API ({jep}226[]) was created in link:https://github.com/jenkinsci/jenkins/README.adoc[
+* The external fingerprint storage API ({jep}226[JEP-226]) was created in link:https://github.com/jenkinsci/jenkins/README.adoc[
 Jenkins core]. Following are the relevant PRs:
 
 ** link:https://github.com/jenkinsci/jenkins/pull/4731[PR-4731]
@@ -106,7 +106,7 @@ link:https://docs.google.com/presentation/d/1QL5m-7QGtep_G1ysEYKRauAHzDq8nTtOdcn
 == The External Fingerprint Storage API
 
 This section explains the external fingerprint storage API that was created in Jenkins core.
-For further details, please refer to {jep}226/README.adoc[] which explains the design decisions in detail.
+For further details, please refer to {jep}226/README.adoc[JEP-226] which explains the design decisions in detail.
 
 image:images:ROOT:post-images/gsoc-external-fingerprint-storage-for-jenkins/overview.png[title="External Fingerprint
 Storage for Jenkins Overview" role="center" width=700 height=400 ]

--- a/docs/sigs/modules/platform/pages/index.adoc
+++ b/docs/sigs/modules/platform/pages/index.adoc
@@ -77,7 +77,7 @@ Scope of interest:
 * Official controller and agent images for Windows
 * Support Multi-architecture Docker images
 * Enabling continuous delivery for Jenkins packaging
-** Experimental DockerHub organization and deployments from ci.jenkins.io ( {jep}217/README.adoc[] )
+** Experimental DockerHub organization and deployments from ci.jenkins.io ( {jep}217/README.adoc[JEP-217] )
 
 == Plugin management
 

--- a/docs/user-docs/modules/managing/pages/system-properties.adoc
+++ b/docs/user-docs/modules/managing/pages/system-properties.adoc
@@ -994,7 +994,7 @@ See link:https://www.jenkins.io/doc/upgrade-guide/2.303///SECURITY-2458[the desc
 *Description*::
 Allow or disallow the deserialization of specified types.
 Comma-separated class names, entries are whitelisted unless prefixed with `!`.
-See jep:200//backwards-compatibility[JEP-200] and https://issues.jenkins.io/browse/JENKINS-47736[JENKINS-47736].
+See {jep}200/backwards-compatibility[JEP-200] and https://issues.jenkins.io/browse/JENKINS-47736[JENKINS-47736].
 
 ===== name: hudson.scheduledRetention
 

--- a/docs/user-docs/modules/security/pages/permissions.adoc
+++ b/docs/user-docs/modules/security/pages/permissions.adoc
@@ -114,7 +114,7 @@ It works best when combined with the _ExtendedRead_ permission that allows read-
 
 This permission can be enabled by setting xref:user-docs:managing:system-properties.adoc#jenkins-security-systemreadpermission[the system property `jenkins.security.SystemReadPermission` to `true`] or installing the {plugin}extended-read-permission[Extended Read Permission] plugin.
 
-Learn more in jep:224[].
+Learn more in {jep}224[JEP-224].
 
 NOTE: This permission was added in Jenkins 2.222.
 Some features, especially those provided by plugins, may not yet support this permission.
@@ -131,7 +131,7 @@ Options generally considered critical to the security of Jenkins are not availab
 
 This permission can be enabled by setting xref:user-docs:managing:system-properties.adoc#jenkins-security-managepermission[the system property `jenkins.security.ManagePermission` to `true`] or installing the {plugin}manage-permission[Overall/Manage permission enabler] plugin.
 
-Learn more in jep:223[].
+Learn more in {jep}223[JEP-223].
 
 NOTE: This permission was added in Jenkins 2.222.
 Some features, especially those provided by plugins, may not yet support this permission.

--- a/docs/user-docs/modules/using-jenkins/pages/pluggable-storage.adoc
+++ b/docs/user-docs/modules/using-jenkins/pages/pluggable-storage.adoc
@@ -24,7 +24,7 @@ Below you can find a summary of ongoing activities and their current status:
 | **Artifacts** +
   **(Available)**
 | Fully delivered, with support for uploading artifacts directly from agents.
-  Related JEPs: jep:202[].
+  Related JEPs: {jep}202[JEP-202].
 
   xref:dev-docs:extensions:jenkins-core.adoc#artifactmanagerfactory[Extension point]
 
@@ -44,11 +44,11 @@ xref:dev-docs:extensions:credentials.adoc#credentialsprovider[Extension point]
 | Build logs +
   (Preview / Paused)
 | Pipeline Log Storage API and reference implementations are available for preview, only Jenkins Pipeline job types are supported.
-  Related JEP: jep:210[].
+  Related JEP: {jep}210[JEP-210].
 
   Jenkins core APIs and reference implementations have not been merged/released yet,
   but prototypes are available for evaluation.
-  Related JEPs: jep:207[], jep:212[]
+  Related JEPs: {jep}207[JEP-207], {jep}212[JEP-212]
 a| Pipeline logging:
 
 * https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin[AWS CloudWatch]
@@ -76,7 +76,7 @@ Jenkins core:
 | Largely replaced by the {plugin}configuration-as-code[Configuration as Code] plugin
   which allows storing Jenkins configurations in SCM or other locations without a database.
 
-  Related JEPs: jep:213[]
+  Related JEPs: {jep}213[JEP-213]
 | N/A
 
 | **Test Results** +
@@ -108,7 +108,7 @@ Jenkins core:
 | Jenkins 2.252+ include the external fingerprint storage API which can be consumed by plugins.
   More info: xref:projects:gsoc:2020/projects/external-fingerprint-storage.adoc[GSoC Project Page]
 
-  Related JEPs: jep:226[]
+  Related JEPs: {jep}226[JEP-226]
 | {plugin}redis-fingerprint-storage[Redis],
   link:https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin[PostgreSQL (unreleased)]
 
@@ -147,7 +147,7 @@ Implementation example(s):
 
 Related JEPs:
 
-* jep:202[External Artifact Storage]
+* {jep}202[External Artifact Storage]
 
 === Build Log Storage
 
@@ -163,10 +163,10 @@ Reference implementation(s):
 
 Related JEPs:
 
-* jep:207[External Build Logging support in the Jenkins Core]
-* jep:210[External log storage for Pipeline]
-* jep:212[External Logging API Plugin]
-* jep:206[Use UTF-8 for Pipeline build logs]
+* {jep}207[External Build Logging support in the Jenkins Core]
+* {jep}210[External log storage for Pipeline]
+* {jep}212[External Logging API Plugin]
+* {jep}206[Use UTF-8 for Pipeline build logs]
 
 === Configuration Storage
 
@@ -182,7 +182,7 @@ There are also other implementations which could be upstreamed to the Jenkins co
 
 Related JEPs:
 
-* jep:213[Configuration Storage API in the Jenkins Core]
+* {jep}213[Configuration Storage API in the Jenkins Core]
 
 === Credentials
 
@@ -225,6 +225,6 @@ Another advantage is that it would allow tracing fingerprints across Jenkins ins
 Status:
 
 * In progress
-* Related JEP: jep:226[External Fingerprint Storage]
+* Related JEP: {jep}226[External Fingerprint Storage]
 * link:https://github.com/jenkinsci/jenkins/pull/4731[Prototype API]
 * Reference Implementation: link:https://github.com/jenkinsci/redis-fingerprint-storage-plugin[Redis Fingerprint Storage Plugin]


### PR DESCRIPTION
On some pages, the link to JEPs was not working. The syntax of Asciidoc attribute was wrong in corresponding Asciidoc files.
This PR fixes their syntax.