### PR TITLE
fix: correct branch for preview

### DIFF
--- a/docs/dev-docs/modules/ROOT/pages/index.adoc
+++ b/docs/dev-docs/modules/ROOT/pages/index.adoc
@@ -40,7 +40,7 @@ xref:guides:index.adoc[Check Out]
 
 .Reference Documentation
 ****
-The Jenkins developer reference documentation is organised by topics.
+The Jenkins developer reference documentation is organized by topics.
 
 xref:reference:index.adoc[Check Out]
 

--- a/docs/dev-docs/modules/ROOT/pages/index.adoc
+++ b/docs/dev-docs/modules/ROOT/pages/index.adoc
@@ -40,7 +40,7 @@ xref:guides:index.adoc[Check Out]
 
 .Reference Documentation
 ****
-The Jenkins developer reference documentation is organized by topics.
+The Jenkins developer reference documentation is organised by topics.
 
 xref:reference:index.adoc[Check Out]
 

--- a/playbook/antora-playbook.yml
+++ b/playbook/antora-playbook.yml
@@ -7,11 +7,11 @@ site:
 content:
   sources:
     - url: https://github.com/jenkins-infra/docs.jenkins.io.git
-      branches: [main]
+      branches: [HEAD]
       start_paths: [docs/solutions, docs/tutorials, docs/user-docs]
       # developer docs are un-versioned that's why they're fetched individually
     - url: https://github.com/jenkins-infra/docs.jenkins.io.git
-      branches: [main]
+      branches: [HEAD]
       start_paths:
         [
           docs/about,

--- a/playbook/local-antora-playbook.yml
+++ b/playbook/local-antora-playbook.yml
@@ -7,12 +7,12 @@ content:
   sources:
     - url: ../
       # Change the branch name to the one you are working on for preview
-      branches: [main]
+      branches: [HEAD]
       start_paths: [docs/solutions, docs/tutorials, docs/user-docs]
       # developer docs are un-versioned that's why they're fetched individually
     - url: ../
       # Change the branch name to the one you are working on for preview
-      branches: [main]
+      branches: [HEAD]
       start_paths:
         [
           docs/about,

--- a/playbook/local-antora-playbook.yml
+++ b/playbook/local-antora-playbook.yml
@@ -6,12 +6,10 @@ site:
 content:
   sources:
     - url: ../
-      # Change the branch name to the one you are working on for preview
       branches: [HEAD]
       start_paths: [docs/solutions, docs/tutorials, docs/user-docs]
       # developer docs are un-versioned that's why they're fetched individually
     - url: ../
-      # Change the branch name to the one you are working on for preview
       branches: [HEAD]
       start_paths:
         [


### PR DESCRIPTION
This PR set the current branch in Antora playbooks instead of `main` so the preview takes in account changes.

From https://deploy-preview-59--docs-jenkins-io.netlify.app/dev-docs/

<img width="671" alt="image" src="https://github.com/jenkins-infra/docs.jenkins.io/assets/91831478/b6c91af4-09e4-487f-87f9-bbf72acc07d7">

Ref:
- https://github.com/jenkins-infra/docs.jenkins.io/pull/47#issuecomment-2147902503
