### PR TITLE
make about.adoc blueocean root

### DIFF
--- a/docs/projects/modules/blueocean/nav.adoc
+++ b/docs/projects/modules/blueocean/nav.adoc
@@ -1,3 +1,2 @@
-.xref:index.adoc[]
-* xref:about.adoc[]
+.xref:about.adoc[]
 * xref:contribute.adoc[]


### PR DESCRIPTION
**What**
Fixes #62.

**How**
Between the 2 suggestions proposed in #62, IMHO in terms of UX/behavior, it is more coherent with the other "Projects" pages to have the about.adoc at the root, as opposed to having index.adoc link to a page outside of "Projects" and into "user-docs". For example, "[Jenkins in Google Summer of Code](https://docs.jenkins.io/projects/gsoc/index.html)", "[Jenkins Configuration as Code](https://docs.jenkins.io/projects/jcasc/index.html)", and "[Infrastructure](https://docs.jenkins.io/projects/infrastructure/index.html)", all "Projects" pages, link to a page within "Projects."

Please do let me know if this needs any changes!