### PR TITLE
fix: adjusted iframe size for desktop and mobile view for Blue Ocean About page

### DIFF
--- a/docs/projects/modules/blueocean/pages/about.adoc
+++ b/docs/projects/modules/blueocean/pages/about.adoc
@@ -51,7 +51,7 @@ Also available for download in link:https://www.dropbox.com/s/1824kdeh0czdgna/Bl
 ++++
 <center>
     <iframe width="853" height="480"
-    style={{maxWidth: "100%"}}
+    style="max-width: 100%"
     src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
     allowfullscreen></iframe>
 </center>

--- a/docs/projects/modules/blueocean/pages/about.adoc
+++ b/docs/projects/modules/blueocean/pages/about.adoc
@@ -51,6 +51,7 @@ Also available for download in link:https://www.dropbox.com/s/1824kdeh0czdgna/Bl
 ++++
 <center>
     <iframe width="853" height="480"
+    style={{maxWidth: "100%"}}
     src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
     allowfullscreen></iframe>
 </center>

--- a/docs/user-docs/modules/blueocean/pages/index.adoc
+++ b/docs/user-docs/modules/blueocean/pages/index.adoc
@@ -44,6 +44,7 @@ If you would like to start using Blue Ocean, please refer to xref:getting-starte
 ++++
 <center>
 <iframe width="853" height="480"
+style="max-width: 100%"
 src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
 allowfullscreen></iframe>
 </center>
@@ -89,6 +90,7 @@ If you are interested in contributing to a plugin which serves a similar purpose
 ++++
 <center>
 <iframe width="853" height="480"
+style="max-width: 100%"
 src="https://www.youtube-nocookie.com/embed/mn61VFdScuk?rel=0" frameborder="0"
 allowfullscreen></iframe>
 </center>

--- a/docs/user-docs/modules/blueocean/pages/index.adoc
+++ b/docs/user-docs/modules/blueocean/pages/index.adoc
@@ -44,7 +44,6 @@ If you would like to start using Blue Ocean, please refer to xref:getting-starte
 ++++
 <center>
 <iframe width="853" height="480"
-style="max-width: 100%"
 src="https://www.youtube-nocookie.com/embed/k_fVlU1FwP4?rel=0" frameborder="0"
 allowfullscreen></iframe>
 </center>
@@ -90,7 +89,6 @@ If you are interested in contributing to a plugin which serves a similar purpose
 ++++
 <center>
 <iframe width="853" height="480"
-style="max-width: 100%"
 src="https://www.youtube-nocookie.com/embed/mn61VFdScuk?rel=0" frameborder="0"
 allowfullscreen></iframe>
 </center>


### PR DESCRIPTION
[Fixes #150]

Before Changes 
Desktop
<img width="864" alt="Screenshot 2024-10-17 at 2 54 00 PM" src="https://github.com/user-attachments/assets/aab87fd1-40db-4ad2-a212-b6157e36c584">
Mobile
<img width="317" alt="Screenshot 2024-10-17 at 2 54 33 PM" src="https://github.com/user-attachments/assets/ce755ac6-9148-4d04-bd07-765074cf1a56">
<img width="321" alt="Screenshot 2024-10-17 at 2 55 00 PM" src="https://github.com/user-attachments/assets/8f0ca76b-1efa-43fc-be56-feb41d84993e">

After changes
Desktop
<img width="992" alt="Screenshot 2024-10-17 at 3 07 36 PM" src="https://github.com/user-attachments/assets/75658921-6526-4d71-b79b-1a77ffef15bb">
Mobile
<img width="321" alt="Screenshot 2024-10-17 at 3 05 30 PM" src="https://github.com/user-attachments/assets/f618b63b-0642-4ba7-ae21-0ba40fa3ecd3">

