### PR TITLE
Update the documentation at site/ for the Gatsby-based jenkins.io website #123

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,18 @@ The documentation site for Jenkins is split into two parts:
 
 This guide focuses on building the version-controlled documentation using Antora.
 
+== Overview of Gatsby
+
+Gatsby is a React-based framework that allows developers to create fast and optimized websites. It leverages GraphQL for data handling and provides a plugin ecosystem for extended functionality. This project utilizes Gatsby for rendering the non-versioned documentation of Jenkins, enhancing performance and user experience.
+
+== Project Structure
+
+The Gatsby site is structured as follows:
+
+* **src/**: Contains the source files for the site, including components, templates, and styles.
+* **static/**: Static files that are directly served, such as images or fonts.
+* **gatsby-config.js**: Configuration file for Gatsby where you can customize settings and plugins.
+
 === Installing the Prerequisites
 
 [start=1]  

--- a/README.adoc
+++ b/README.adoc
@@ -74,6 +74,10 @@ Once the site is up and running, it should be available locally at:
 * **Gatsby Documentation**: Non-versioned content managed via Gatsby. This forms the basis of the current link:https://jenkins.io/[https://jenkins.io/] site, which will be replaced in the future. For more details on how to work with the Gatsby site, refer to its dedicated README documentation at:
 ** link:https://github.com/jenkins-infra/docs.jenkins.io/tree/main/site#readme/[https://github.com/jenkins-infra/docs.jenkins.io/tree/main/site#readme/][https://github.com/jenkins-infra/docs.jenkins.io/tree/main/site#readme/]
 
+For more details on running the project, refer to the detailed documentation in the `README.md` file:
+
+link:site/README.md[Running the Project Documentation]
+
 == Contributing 
 
 If you have any queries or contributions or updates for the documentation, feel free to create an issue and/or submit a pull request.

--- a/site/README.md
+++ b/site/README.md
@@ -95,7 +95,7 @@ We welcome contributions from the Jenkins community! If you’d like to contribu
 
 Before submitting a pull request, ensure that your changes are aligned with the project's goals and code quality standards. We recommend running the following commands to check for any issues:
 
-- **Build**: `gatsby build` to ensure the build process runs successfully.
+- **Build**: `npm run build` to ensure the build process runs successfully.
 - **Lint**: Use linting tools to ensure your code adheres to project style guidelines.
 
 ## Available Content

--- a/site/README.md
+++ b/site/README.md
@@ -64,7 +64,7 @@ npm install
 To start a local development server, use the following command:
 
 ```bash
-gatsby develop
+npm run clean && npm run develop
 ```
 
 This will start a local server at `http://localhost:8000`, where you can preview changes as you make updates to the project files.

--- a/site/README.md
+++ b/site/README.md
@@ -69,6 +69,20 @@ npm run clean && npm run develop
 
 This will start a local server at `http://localhost:8000`, where you can preview changes as you make updates to the project files.
 
+## Generated Folders
+
+When you run the above command, the following folders are generated:
+
+* **`.cache/`**: Contains cached files that help speed up the development process.
+* **`public/`**: Contains the built assets and files that will be served by the local server.
+
+These folders should be included in your `.gitignore` file to prevent them from being tracked by Git. You can ensure they are ignored by adding the following lines to your `.gitignore` file:
+
+```plaintext
+.cache/
+public/
+```
+
 ## Contributing
 
 We welcome contributions from the Jenkins community! If you’d like to contribute, please follow these steps:


### PR DESCRIPTION
Fixes #123

This pull-request updates the documentation for the Gatsby site hosted in the Jenkins repository. I have made the following changes:

1. Changed the startup command in the README to npm run clean && npm run develop.
2. Added details about the folders generated during the startup process (.cache/ and public/) and included instructions for ignoring these in the .gitignore file.
3. Linked the Gatsby documentation with the root README.adoc for better navigation.
4.Added an overview of Gatsby and information on the project structure to enhance clarity for developers.