### PR TITLE
fix gatsby build error due to the use of browser api's

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "build": "gatsby build",
-    "start": "npm run develop",
+    "serve": "gatsby serve",
     "clean": "gatsby clean",
     "lint": "npx eslint .",
     "format": "npx prettier . --write"

--- a/site/src/components/RecentBlogPosts.js
+++ b/site/src/components/RecentBlogPosts.js
@@ -66,7 +66,7 @@ const RecentBlogPosts = () => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../static/images/gsoc/opengraph.png";
+                        "../../images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
                     function extractTextNodes(element, textNodes) {
@@ -128,7 +128,7 @@ const RecentBlogPosts = () => {
                                                 />
                                             ) : (
                                                 <img
-                                                    src="../../static/images/images/avatars/no_image.svg"
+                                                    src="../../images/images/avatars/no_image.svg"
                                                     className={blogauthorimage}
                                                     loading="lazy"
                                                     alt={""}

--- a/site/src/components/RecentBlogPosts.js
+++ b/site/src/components/RecentBlogPosts.js
@@ -66,11 +66,9 @@ const RecentBlogPosts = () => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../images/gsoc/opengraph.png";
+                        "../../static/images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
-                    const parser = new DOMParser();
-                    const parsedHtml = parser.parseFromString(htmlContent, "text/html");
                     function extractTextNodes(element, textNodes) {
                         if (element.nodeType === Node.TEXT_NODE) {
                             textNodes.push(element.textContent.trim());
@@ -80,10 +78,16 @@ const RecentBlogPosts = () => {
                             }
                         }
                     }
-                    const textNodes = [];
-                    extractTextNodes(parsedHtml.body, textNodes);
-                    const blogTeaser = textNodes.join(" ");
 
+                    let blogTeaser = [];
+                    if (typeof window !== "undefined") {
+                        const parser = new DOMParser();
+                        const parsedHtml = parser.parseFromString(htmlContent, "text/html");
+
+                        const textNodes = [];
+                        extractTextNodes(parsedHtml.body, textNodes);
+                        blogTeaser = textNodes.join(" ");
+                    }
                     return (
                         <li
                             key={`${childrenAsciidoc[0].fields.slug}-${childrenAsciidoc[0].document.title}`}
@@ -124,7 +128,7 @@ const RecentBlogPosts = () => {
                                                 />
                                             ) : (
                                                 <img
-                                                    src="../../images/images/avatars/no_image.svg"
+                                                    src="../../static/images/images/avatars/no_image.svg"
                                                     className={blogauthorimage}
                                                     loading="lazy"
                                                     alt={""}

--- a/site/src/templates/author-pages.js
+++ b/site/src/templates/author-pages.js
@@ -44,7 +44,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                     src={
                                         node.node.pageAttributes.authoravatar
                                             ? node.node.pageAttributes.authoravatar
-                                            : "../../images/avatars/no_image.svg"
+                                            : "../../images/images/avatars/no_image.svg"
                                     }
                                     alt={node.node.pageAttributes.author_name}
                                 />

--- a/site/src/templates/author-pages.js
+++ b/site/src/templates/author-pages.js
@@ -44,7 +44,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                     src={
                                         node.node.pageAttributes.authoravatar
                                             ? node.node.pageAttributes.authoravatar
-                                            : "../../images/images/avatars/no_image.svg"
+                                            : "../../static/images/avatars/no_image.svg"
                                     }
                                     alt={node.node.pageAttributes.author_name}
                                 />
@@ -109,11 +109,9 @@ const AuthorPage = ({ data, pageContext, path }) => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../images/gsoc/opengraph.png";
+                        "../../static/images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
-                    const parser = new DOMParser();
-                    const parsedHtml = parser.parseFromString(htmlContent, "text/html");
                     function extractTextNodes(element, textNodes) {
                         if (element.nodeType === Node.TEXT_NODE) {
                             textNodes.push(element.textContent.trim());
@@ -123,10 +121,16 @@ const AuthorPage = ({ data, pageContext, path }) => {
                             }
                         }
                     }
-                    const textNodes = [];
-                    extractTextNodes(parsedHtml.body, textNodes);
-                    const blogTeaser = textNodes.join(" ");
 
+                    let blogTeaser = [];
+                    if (typeof window !== "undefined") {
+                        const parser = new DOMParser();
+                        const parsedHtml = parser.parseFromString(htmlContent, "text/html");
+
+                        const textNodes = [];
+                        extractTextNodes(parsedHtml.body, textNodes);
+                        blogTeaser = textNodes.join(" ");
+                    }
                     return (
                         <li
                             key={`${childrenAsciidoc[0].fields.slug}-${childrenAsciidoc[0].document.title}`}
@@ -141,7 +145,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                     flexDirection: "column",
                                 }}
                             >
-                                <div className={{ authorimagecontainer }}>
+                                <div className={authorimagecontainer}>
                                     <img
                                         src={opengraphImageSource}
                                         alt={childrenAsciidoc[0].document.title}
@@ -155,47 +159,52 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                 </div>
                                 <div style={{ display: "flex", justifyContent: "space-between" }}>
                                     <div className={blogauthorinfo}>
-                                        {authorList.map((auth) => {
-                                            return authors.map((node) => {
-                                                return node.node.pageAttributes.github === auth ? (
-                                                    <Link
-                                                        className={blogauthorinfo}
-                                                        to={`/author/${node.node.pageAttributes.github}`}
-                                                    >
-                                                        {node.node.pageAttributes.authoravatar ? (
-                                                            <img
-                                                                loading="lazy"
-                                                                src={
-                                                                    node.node.pageAttributes
-                                                                        .authoravatar
-                                                                }
-                                                                className={blogauthorimage}
-                                                                alt={
-                                                                    node.node.pageAttributes.author
-                                                                }
-                                                            />
-                                                        ) : (
-                                                            <img
-                                                                loading="lazy"
-                                                                src="../../images/images/avatars/no_image.svg"
-                                                                className={blogauthorimage}
-                                                                alt={
-                                                                    node.node.pageAttributes.author
-                                                                }
-                                                            />
-                                                        )}
-                                                        {authorList.length < 3 ? (
-                                                            <p>
-                                                                {
-                                                                    node.node.pageAttributes
-                                                                        .author_name
-                                                                }
-                                                            </p>
-                                                        ) : null}
-                                                    </Link>
-                                                ) : null;
-                                            });
-                                        })}
+                                        {Array.isArray(authorList) &&
+                                            authorList.map((auth) => {
+                                                return authors.map((node) => {
+                                                    return node.node.pageAttributes.github ===
+                                                        auth ? (
+                                                        <Link
+                                                            className={blogauthorinfo}
+                                                            to={`/author/${node.node.pageAttributes.github}`}
+                                                        >
+                                                            {node.node.pageAttributes
+                                                                .authoravatar ? (
+                                                                <img
+                                                                    loading="lazy"
+                                                                    src={
+                                                                        node.node.pageAttributes
+                                                                            .authoravatar
+                                                                    }
+                                                                    className={blogauthorimage}
+                                                                    alt={
+                                                                        node.node.pageAttributes
+                                                                            .author
+                                                                    }
+                                                                />
+                                                            ) : (
+                                                                <img
+                                                                    loading="lazy"
+                                                                    src="../../static/images/images/avatars/no_image.svg"
+                                                                    className={blogauthorimage}
+                                                                    alt={
+                                                                        node.node.pageAttributes
+                                                                            .author
+                                                                    }
+                                                                />
+                                                            )}
+                                                            {authorList.length < 3 ? (
+                                                                <p>
+                                                                    {
+                                                                        node.node.pageAttributes
+                                                                            .author_name
+                                                                    }
+                                                                </p>
+                                                            ) : null}
+                                                        </Link>
+                                                    ) : null;
+                                                });
+                                            })}
                                     </div>
                                     <span>{formattedDate}</span>
                                 </div>

--- a/site/src/templates/author-pages.js
+++ b/site/src/templates/author-pages.js
@@ -44,7 +44,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                     src={
                                         node.node.pageAttributes.authoravatar
                                             ? node.node.pageAttributes.authoravatar
-                                            : "../../static/images/avatars/no_image.svg"
+                                            : "../../images/avatars/no_image.svg"
                                     }
                                     alt={node.node.pageAttributes.author_name}
                                 />
@@ -109,7 +109,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../static/images/gsoc/opengraph.png";
+                        "../../images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
                     function extractTextNodes(element, textNodes) {
@@ -185,7 +185,7 @@ const AuthorPage = ({ data, pageContext, path }) => {
                                                             ) : (
                                                                 <img
                                                                     loading="lazy"
-                                                                    src="../../static/images/images/avatars/no_image.svg"
+                                                                    src="../../images/images/avatars/no_image.svg"
                                                                     className={blogauthorimage}
                                                                     alt={
                                                                         node.node.pageAttributes

--- a/site/src/templates/blog-list-template.js
+++ b/site/src/templates/blog-list-template.js
@@ -30,7 +30,7 @@ const BlogIndex = ({ pageContext, data }) => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../static/images/gsoc/opengraph.png";
+                        "../../images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
                     function extractTextNodes(element, textNodes) {
@@ -102,7 +102,7 @@ const BlogIndex = ({ pageContext, data }) => {
                                                         ) : (
                                                             <img
                                                                 loading="lazy"
-                                                                src="../../static/images/images/avatars/no_image.svg"
+                                                                src="../../images/images/avatars/no_image.svg"
                                                                 className={blogauthorimage}
                                                                 alt={
                                                                     node.node.pageAttributes.author

--- a/site/src/templates/blog-list-template.js
+++ b/site/src/templates/blog-list-template.js
@@ -30,11 +30,9 @@ const BlogIndex = ({ pageContext, data }) => {
                     const formattedDate = formatDate(childrenAsciidoc[0].fields.slug);
                     const opengraphImageSource =
                         childrenAsciidoc[0].pageAttributes.opengraph ||
-                        "../../images/gsoc/opengraph.png";
+                        "../../static/images/gsoc/opengraph.png";
 
                     const htmlContent = childrenAsciidoc[0].html;
-                    const parser = new DOMParser();
-                    const parsedHtml = parser.parseFromString(htmlContent, "text/html");
                     function extractTextNodes(element, textNodes) {
                         if (element.nodeType === Node.TEXT_NODE) {
                             textNodes.push(element.textContent.trim());
@@ -44,10 +42,15 @@ const BlogIndex = ({ pageContext, data }) => {
                             }
                         }
                     }
-                    const textNodes = [];
-                    extractTextNodes(parsedHtml.body, textNodes);
-                    const blogTeaser = textNodes.join(" ");
+                    let blogTeaser = [];
+                    if (typeof window !== "undefined") {
+                        const parser = new DOMParser();
+                        const parsedHtml = parser.parseFromString(htmlContent, "text/html");
 
+                        const textNodes = [];
+                        extractTextNodes(parsedHtml.body, textNodes);
+                        blogTeaser = textNodes.join(" ");
+                    }
                     return (
                         <li
                             key={`${childrenAsciidoc[0].fields.slug}-${childrenAsciidoc[0].document.title}`}
@@ -99,7 +102,7 @@ const BlogIndex = ({ pageContext, data }) => {
                                                         ) : (
                                                             <img
                                                                 loading="lazy"
-                                                                src="../../images/images/avatars/no_image.svg"
+                                                                src="../../static/images/images/avatars/no_image.svg"
                                                                 className={blogauthorimage}
                                                                 alt={
                                                                     node.node.pageAttributes.author

--- a/site/src/utils/blogAuthorImage.js
+++ b/site/src/utils/blogAuthorImage.js
@@ -4,5 +4,5 @@ export function blogAuthorImage(input) {
         input = input.split(",");
         return input;
     }
-    return "";
+    return [];
 }

--- a/site/src/utils/getImageSrc.js
+++ b/site/src/utils/getImageSrc.js
@@ -1,6 +1,10 @@
 export function getImageSrc(author, formats) {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
     for (const format of formats) {
-        const imgPath = `../../images/images/avatars/${author}.${format}`;
+        const imgPath = `../../static/images/images/avatars/${author}.${format}`;
         const img = new Image();
         img.src = imgPath;
         if (img.width > 0) {

--- a/site/src/utils/getImageSrc.js
+++ b/site/src/utils/getImageSrc.js
@@ -4,7 +4,7 @@ export function getImageSrc(author, formats) {
     }
 
     for (const format of formats) {
-        const imgPath = `../../static/images/images/avatars/${author}.${format}`;
+        const imgPath = `../../images/images/avatars/${author}.${format}`;
         const img = new Image();
         img.src = imgPath;
         if (img.width > 0) {


### PR DESCRIPTION
Fixes #127

![image](https://github.com/user-attachments/assets/1e960a46-4e0b-4d59-b2db-c21952df27aa)

I added if checks so that code requiring browser apis are only executed on client side.
Build successful on my device.

I even tried to use polyfills such as  xmldom and jsdom, but it was not an optimal approach.

@krisstern  can you check this out and mention if something needs to be fixed?