### PR TITLE
Fix the missing left nav bar entries in developer docs

### DIFF
--- a/docs/dev-docs/modules/FIPS-140/nav.adoc
+++ b/docs/dev-docs/modules/FIPS-140/nav.adoc
@@ -1,2 +1,2 @@
 []
-.xref:index.adoc[]
+* xref:index.adoc[]

--- a/docs/dev-docs/modules/guides/nav.adoc
+++ b/docs/dev-docs/modules/guides/nav.adoc
@@ -1,2 +1,2 @@
 []
-.xref:index.adoc[]
+* xref:index.adoc[]

--- a/docs/dev-docs/modules/reference/nav.adoc
+++ b/docs/dev-docs/modules/reference/nav.adoc
@@ -1,2 +1,2 @@
 []
-.xref:index.adoc[]
+* xref:index.adoc[]

--- a/docs/dev-docs/modules/testing/nav.adoc
+++ b/docs/dev-docs/modules/testing/nav.adoc
@@ -1,1 +1,2 @@
-.xref:index.adoc[]
+[]
+* xref:index.adoc[]


### PR DESCRIPTION
While trying to read the `Testing` documenation on `docs.jenkins.io` noticed that it wasn't appearing in the left navigation bar.
Later checking it appeared the issue was,
* asciidoc navigation bar seems to not render the `.xref` if there are not list items (`* xref`) under that
* later comparing to other single doc pages that are added in left navbar, like `Telemetry`; learnt that it could be fixed by simply changing from `.xref` to `* xref` for single pages.

Checked other similar missing pages from nav bar, found 3 more by comparing with [antora.yml file](https://github.com/jenkins-infra/docs.jenkins.io/blob/main/docs/dev-docs/antora.yml), fixed them as well.

Tested locally by [following the contributor guidelines section](https://github.com/jenkins-infra/docs.jenkins.io/blob/451541c390bf8e22e4fe59a7b6e70410a22fdae2/CONTRIBUTING.adoc#building-the-antora-documentation)

|Current: docs.jenkins.io|After Fixing: local server|
|---|---|
|![image](https://github.com/user-attachments/assets/592ea398-4a5d-46f6-968f-1376c13f5c39)|![image](https://github.com/user-attachments/assets/0451fd11-f251-4fb6-b408-03815e4ff30a)|