### PR TITLE
Use SARIF format for typos check in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,11 +13,11 @@ pipeline {
   stages {
     stage('Check for typos') {
       steps {
-        sh './typos --format json | ./typos-checkstyle - > checkstyle.xml || true'
+        sh 'typos --format sarif > typos.sarif || true'
       }
       post {
         always {
-          recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')])
+          recordIssues(tools: [sarif(id: 'typos', name: 'Typos', pattern: 'typos.sarif')])
         }
       }
     }


### PR DESCRIPTION
The path to the tool was wrong (it's installed globally) and `typos-checkstyle` is no longer needed.