### PR TITLE
chore(.gitlab-ci.yml): replace npm install with npm ci

### DIFF
--- a/ui/.gitlab-ci.yml
+++ b/ui/.gitlab-ci.yml
@@ -6,7 +6,7 @@ install:
     paths:
       - .cache/npm
   script:
-    - &npm_install npm install --quiet --no-progress --cache=.cache/npm
+    - &npm_install npm ci --quiet --no-progress --cache=.cache/npm
 lint:
   stage: verify
   cache: &pull_cache


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5119

enforcing npm ci over npm install across CI/CD pipelines for reproducible builds.