### PR TITLE
chore(Jenkinsfile) build/deploy once a day at least

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,10 @@
+// Do not trigger daily if not on the principal branch (e.g. not on PR, not on other branches, not on tags)
+String cronPattern = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+
 pipeline {
+  triggers {
+    cron(cronPattern)
+  }
   options {
     timeout(time: 60, unit: 'MINUTES')
     ansiColor('xterm')


### PR DESCRIPTION
Following CI/CD princples, we should run the build (and deployment) at least once a day.

This PR adds a cron daily trigger, only on the principal branch, in the pipeline (both for ci.jenkins.io CI build and infra.ci.jenkins.io Deployment builds).

It also eases monitoring of failing jobs (see https://github.com/jenkins-infra/helpdesk/issues/5159)